### PR TITLE
Increase the height of the spark lines

### DIFF
--- a/public/app/plugins/panels/singlestat/singleStatPanel.js
+++ b/public/app/plugins/panels/singlestat/singleStatPanel.js
@@ -97,7 +97,7 @@ function (angular, app, _, $) {
             plotCss.bottom = '5px';
             plotCss.left = '-5px';
             plotCss.width = (width - 10) + 'px';
-            plotCss.height = (height - 45) + 'px';
+            plotCss.height = (height - 5) + 'px';
           }
           else {
             plotCss.bottom = "0px";


### PR DESCRIPTION
Simple change to increase the canvas height to allow better space usage for small panels in background mode. I think it looks much neater and makes the changes more visible.

![image](https://cloud.githubusercontent.com/assets/14072681/11880690/31198414-a4fa-11e5-85be-13a11c8b01e2.png)
